### PR TITLE
Solve layers of indirection problem with /run/current-system/sw/bin

### DIFF
--- a/nix-bwrap.tcl
+++ b/nix-bwrap.tcl
@@ -50,11 +50,8 @@ try {
   set is_nixos 0
 }
 
-# there used to be a realpath
-# (or ::fileutil::fullnormalize, file normalize, file readlink) call here, but
-# it makes single-executable tools (such as busybox or coreutils) useless
-# MAYBE do it only for /run/current-system/sw/bin
-set exe [exec which [lindex $::argv 0]]
+set argv0 [lindex $::argv 0]
+set exe [exec realpath [exec which $argv0]]
 set args [lreplace $::argv 0 0]
 
 set bwrap_options [list --unshare-all --clearenv --setenv HOME $env(HOME)]
@@ -136,7 +133,7 @@ if {$params(extra-store-paths) != ""} {
 lappend bwrap_options {*}$params(bwrap-options)
 
 try {
-  exec bwrap {*}$bwrap_options $exe {*}$args <@stdin >@stdout 2>@stderr
+  exec bwrap {*}$bwrap_options --argv0 $argv0 $exe {*}$args <@stdin >@stdout 2>@stderr
 } trap CHILDSTATUS {- options} {
   exit [lindex [dict get $options -errorcode] 2]
 }


### PR DESCRIPTION
Bubblewrap is adding a new --argv0 option. This means that the command name can remain unchanged, while the exe to execute can have realpath applied to it.

Test-1: coreutils provided command on NixOS
```
nix-bwrap date
```
Test-2: /run/current-system/sw/bin/ located binary on NixOS
```
nix-bwrap find / 
```

Note that --argv0 was only merged into bubblewrap today and there has not been an offical release. See: https://github.com/containers/bubblewrap/issues/91